### PR TITLE
coursera: Download subtitles for languages other than English.

### DIFF
--- a/coursera/coursera_dl.py
+++ b/coursera/coursera_dl.py
@@ -135,6 +135,32 @@ def grab_hidden_video_url(session, href):
         return None
 
 
+def grab_more_subtitles(session, href):
+    """
+    Follow some extra redirects to grab more subtitles for the videos.  We
+    return a list of tuples, where each tuple is a pair of the form language
+    and URL. An example of a tuple:
+
+    ('pt',
+    'https://class.coursera.org/introfinance-005/lecture/subtitles?q=188_pt')
+    """
+    try:
+        page = get_page(session, href)
+    except requests.exceptions.HTTPError:
+        return None
+
+    soup = BeautifulSoup(page)
+    l = soup.find_all('track', attrs={'kind': 'subtitles'})
+
+    if l is not None:
+        subtitles = []
+        for i in l:
+            subtitles.append((i['srclang'], i['src']))
+        return subtitles
+    else:
+        return None
+
+
 def get_syllabus(session, class_name, local_page=False, preview=False):
     """
     Get the course listing webpage.


### PR DESCRIPTION
This is an initial, brute-force, kludgy, not yet hooked implementation into
the main script, only tested interactively (read: "from ipython") for
downloading subtitles for other languages.

It is slow and should probably be replaced with the use of Coursera's API
(if it offers what we need) for a more site-friendly solution.

Signed-off-by: Rogério Brito <rbrito@ime.usp.br>