### PR TITLE
Optionally use keyring to store credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ In any case, you may want to install:
 * [easy_install][7]: Only necessary if not using prepackaged
   dependencies. Also, `pip` supersedes it.
   - Ubuntu/Debian: `sudo apt-get install python-setuptools`
+* [keyring][20]: Optional. For storing credentials in system keyring (Mac OS X Keychain, Linux Secret Service, Windows Credential Vault).
+  - All: `pip install keyring`
 
 Again, make sure that you have the versions mentioned in the file
 `requirements.txt` (later versions may be OK).
@@ -302,6 +304,7 @@ first last at geemail dotcom or [@jplehmann][12]
 [17]: http://www.pip-installer.org/en/latest/
 [18]: http://python-distribute.org/pip_distribute.png
 [19]: https://pypi.python.org/pypi/six/
+[20]: https://pypi.python.org/pypi/keyring
 
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/coursera-dl/coursera/trend.png)](https://bitdeli.com/free "Bitdeli Badge")

--- a/coursera/credentials.py
+++ b/coursera/credentials.py
@@ -10,6 +10,13 @@ import netrc
 import os
 import platform
 
+try:
+    import keyring
+except ImportError:
+    keyring = None
+
+KEYRING_SERVICE_NAME = 'coursera-dl'
+
 
 class CredentialsError(BaseException):
     """
@@ -129,7 +136,7 @@ def authenticate_through_netrc(path=None):
         'Did not find valid netrc file:\n' + error_messages)
 
 
-def get_credentials(username=None, password=None, netrc=None):
+def get_credentials(username=None, password=None, netrc=None, use_keyring=False):
     """
     Returns valid username, password tuple.
     Raises CredentialsError if username or password is missing.
@@ -143,8 +150,12 @@ def get_credentials(username=None, password=None, netrc=None):
             'Please provide a username with the -u option, '
             'or a .netrc file with the -n option.')
 
+    if not password and use_keyring:
+        password = keyring.get_password(KEYRING_SERVICE_NAME, username)
+
     if not password:
-        password = getpass.getpass(
-            'Coursera password for {0}: '.format(username))
+        password = getpass.getpass('Coursera password for {0}: '.format(username))
+        if use_keyring:
+            keyring.set_password(KEYRING_SERVICE_NAME, username, password)
 
     return username, password

--- a/coursera/test/test_credentials.py
+++ b/coursera/test/test_credentials.py
@@ -48,13 +48,13 @@ class CredentialsTestCase(unittest.TestCase):
         self.assertEquals(username, 'user')
         self.assertEquals(password, 'pass')
 
-    def test_get_credentials_with_username_given(self):
+    def test_get_credentials_with_username_given(self, use_keyring=False):
         import getpass
         _getpass = getpass.getpass
         getpass.getpass = lambda x: 'pass'
 
         username, password = credentials.get_credentials(
-            username='user')
+            username='user', use_keyring=use_keyring)
         self.assertEquals(username, 'user')
         self.assertEquals(password, 'pass')
 
@@ -64,3 +64,14 @@ class CredentialsTestCase(unittest.TestCase):
         self.assertRaises(
             credentials.CredentialsError,
             credentials.get_credentials)
+
+    def test_get_credentials_with_keyring(self):
+        if not credentials.keyring:
+            return None
+        self.test_get_credentials_with_username_given(True)
+
+        # Test again, this time without getpass
+        username, password = credentials.get_credentials(
+            username='user', use_keyring=True)
+        self.assertEquals(username, 'user')
+        self.assertEquals(password, 'pass')

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ html5lib>=1.0b2
 nose>=1.3.0
 requests>=2.2.1
 six>=1.3.0
+keyring>=4.0


### PR DESCRIPTION
An optional switch (`-k` or `--keyring`) for storing credential in the system keyring (e.g. Keychain in Mac OS X or Credential Vault in Windows). This is more secure than *netrc* method because keyring usually encrypts the password, and has stricter privilege separation than file system.