### PR TITLE
bump version for the `six` dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ coverage>=3.7
 html5lib>=1.0b2
 nose>=1.3.0
 requests>=2.4.3
-six>=1.3.0
+six>=1.5.0
 mock>=1.0.1


### PR DESCRIPTION
The first version that has `six.PY2` is six v1.4.0. six v1.5.0 is the
lowest version on PyPI right now.