### PR TITLE
Fix issue#300

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 .DS_Store
 _cache/
 .coverage
+
+# virtualenv folders
+venv2
+venv3

--- a/coursera/cookies.py
+++ b/coursera/cookies.py
@@ -117,6 +117,11 @@ def login(session, class_name, username, password):
                      headers=headers, allow_redirects=False)
     try:
         r.raise_for_status()
+
+        # Some how the order of cookies parameters are important
+        # for coursera!!!
+        v = session.cookies.pop('CAUTH')
+        session.cookies.set('CAUTH', v)
     except requests.exceptions.HTTPError:
         raise AuthenticationFailed('Cannot login on accounts.coursera.org.')
 


### PR DESCRIPTION
Somehow the order of cookies parameters are an important fact for
coursera!, for example if there are three parameters in cookies
called: 'csrf_token', 'maestro_login_flag' and 'CAUTH' in exactly that
order, coursera doesn't accept it and redirect the request to signin
page, but if without changing parametes values and just changing their
orders: 'maestor_login_flag', 'CAUTH' and 'csrf_token', coursera accepts
it and fetches the requested page.

Updated .gitignore file to ignore virtualenv folders: 'venv2' and
'venv3'.