### PR TITLE
Add tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+
+[tox]
+envlist = py26,py27,py33,py34,pypy
+
+[testenv]
+downloadcache = .tox/_download/
+
+deps =
+    beautifulsoup4>=4.1.3
+    coverage>=3.7
+    html5lib>=1.0b2
+    mock>=1.0.1
+    nose>=1.3.0
+    pyasn1>=0.1.7
+    pytest>=2.5
+    requests>=2.4.3
+    six>=1.5.0
+    urllib3>=1.10
+
+commands = py.test -v --junitxml={envlogdir}/result.xml \
+    coursera/test


### PR DESCRIPTION
Add Tox support for unit/functional testing. It help testing different versions of Python.
fabfile.py already contains a target to run Tox.

The result.xml files can be parsed with https://github.com/FedericoCeratto/tox-pytest-summary
